### PR TITLE
Add unix socket

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run benchmarks on PR branch
         run: |
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git checkout -
           cargo bench
 
       - name: Upload benchmark results

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ You can directly pull docker containers for client and server. They are publishe
 Make sure that you have docker [installed](https://docs.docker.com/engine/install/)
 
 ```sh
-docker run -d --net=host ghcr.io/nkval/nkv-main:latest ./nkv-server "0.0.0.0:4222"
-docker run -it --net=host ghcr.io/nkval/nkv-main:latest ./nkv-client "4222"
+sudo mkdir /var/run/shared
+docker run --rm -it -v /var/run/shared:/tmp/nkv/ nkv ./nkv-client
+docker run --rm -it -v /var/run/shared:/tmp/nkv/ nkv ./nkv-server
 ```
 
 when using network other than the host, the network implementation may impact network performance, unrelated to nkv itself.

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -5,7 +5,7 @@ use nkv::request_msg::Message;
 use nkv::NkvClient;
 use std::time::Instant;
 
-const DEFAULT_URL: &str = "127.0.0.1:4222";
+const DEFAULT_URL: &str = "/tmp/nkv/nkv.sock";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
@@ -16,6 +16,7 @@ async fn main() {
     } else {
         DEFAULT_URL
     };
+
     let mut client = NkvClient::new(&url);
 
     println!("Please enter the command words separated by whitespace, finish with a character return. Enter HELP for help:");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use crate::request_msg::*;
 use std::collections::HashMap;
 use std::fmt;
 use std::str;
-use tokio::net::TcpStream;
+use tokio::net::UnixStream;
 // use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use uuid::Uuid;
@@ -156,7 +156,7 @@ impl NkvClient {
     }
 
     async fn send_request(&mut self, request: &ServerRequest) -> tokio::io::Result<ServerResponse> {
-        let stream = TcpStream::connect(&self.addr).await?;
+        let stream = UnixStream::connect(&self.addr).await?;
         let (reader, mut writer) = stream.into_split();
 
         let mut buf_reader = BufReader::new(reader);

--- a/src/request_msg.rs
+++ b/src/request_msg.rs
@@ -335,12 +335,26 @@ impl FromStr for ServerResponse {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(PartialEq, Clone)]
 pub enum Message {
     Hello,
     Update { key: String, value: Box<[u8]> },
     Close { key: String },
     NotFound,
+}
+
+impl fmt::Debug for Message {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Hello => write!(f, "HELLO"),
+            Self::Update { key, value } => match std::str::from_utf8(value) {
+                Ok(val) => write!(f, "UPDATE {} {}", key, val),
+                Err(_) => write!(f, "UPDATE {} {:?}", key, value),
+            },
+            Self::Close { key } => write!(f, "CLOSE {}", key),
+            Self::NotFound => write!(f, "NOTFOUND"),
+        }
+    }
 }
 
 impl fmt::Display for Message {

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -1,9 +1,9 @@
-use std::env;
+use std::{env, fs};
 use tempfile::TempDir;
 
 use nkv::srv;
 
-const DEFAULT_URL: &str = "127.0.0.1:4222";
+const DEFAULT_URL: &str = "/tmp/nkv/nkv.sock";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
@@ -14,6 +14,9 @@ async fn main() {
     } else {
         DEFAULT_URL
     };
+    if fs::metadata(url).is_ok() {
+        fs::remove_file(url).expect("Failed to remove old socket");
+    }
 
     let temp_dir = TempDir::new().expect("Failed to create temporary directory");
 


### PR DESCRIPTION
So making universal trait turned out to be way harder than it looks, so instead I've just switched to unix socket instead of TCP. Whoever wants to use TCP, can implement their own server and notifiers, not sure if abstracting over writer right now is a right way to go. For now it'll work good enough for our integration 