### PR TITLE
GitHub Actions: bump upload artifact to v4

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -51,7 +51,7 @@ jobs:
           cargo bench
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
           path: target/criterion


### PR DESCRIPTION
v3 is deprecated, and thus workflows are not running