### PR TITLE
Add flags parsing to nkv-server and nkv-client

### DIFF
--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -1,23 +1,41 @@
 use std::env;
 use std::io::{self, Write};
 
+use nkv::flag_parser::FlagParser;
 use nkv::request_msg::Message;
 use nkv::NkvClient;
 use std::time::Instant;
 
 const DEFAULT_URL: &str = "/tmp/nkv/nkv.sock";
+const HELP_MESSAGE: &str = "nkv-client [--sock path-to-socket] [--help]\
+    run notify key value client\
+    --sock - specify where to create UNIX socket to listen to connections to\
+    --help - display this message";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
+    let allowed_flags = vec!["help".to_string(), "sock".to_string()];
     let args: Vec<String> = env::args().collect();
-
-    let url = if args.len() > 1 {
-        &args[1]
-    } else {
-        DEFAULT_URL
+    let flags = match FlagParser::new(args, Some(allowed_flags)) {
+        Ok(res) => res,
+        Err(err) => {
+            println!("error: {}", err);
+            println!("{}", HELP_MESSAGE);
+            return;
+        }
     };
 
-    let mut client = NkvClient::new(&url);
+    if flags.get("help").is_some() {
+        println!("{}", HELP_MESSAGE);
+        return;
+    }
+
+    let sock_path = match flags.get("sock") {
+        Some(&Some(ref val)) => val.clone(),
+        _ => DEFAULT_URL.to_string(),
+    };
+
+    let mut client = NkvClient::new(&sock_path);
 
     println!("Please enter the command words separated by whitespace, finish with a character return. Enter HELP for help:");
     loop {

--- a/src/flag_parser.rs
+++ b/src/flag_parser.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Simple structure to parse command line arguments
+// in format
+// --key value
+// --help
+
+use core::fmt;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug)]
+pub enum FlagParserError {
+    DuplicateFlag(String),
+    UnkownFlag(String),
+}
+
+impl fmt::Display for FlagParserError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FlagParserError::DuplicateFlag(flag) => write!(f, "Duplicate flag {}", flag),
+            FlagParserError::UnkownFlag(flag) => write!(f, "Unknown flag {}", flag),
+        }
+    }
+}
+
+impl std::error::Error for FlagParserError {}
+
+#[derive(Debug)]
+pub struct FlagParser {
+    flags: HashMap<String, Option<String>>,
+}
+
+impl FlagParser {
+    pub fn new(
+        args: Vec<String>,
+        allowed_flags: Option<Vec<String>>,
+    ) -> Result<Self, FlagParserError> {
+        let mut flags: HashMap<String, Option<String>> = HashMap::new();
+        let mut iter = args.iter().peekable();
+        while let Some(arg) = iter.next() {
+            if let Some(flag) = arg.strip_prefix("--") {
+                if flags.contains_key(flag) {
+                    return Err(FlagParserError::DuplicateFlag(flag.to_string()));
+                }
+                if let Some(value) = iter.peek() {
+                    if value.starts_with("--") {
+                        // next token is new flag, we just add this one
+                        flags.insert(flag.to_string(), None);
+                    } else {
+                        flags.insert(flag.to_string(), Some(value.to_string()));
+                        iter.next();
+                    }
+                } else {
+                    flags.insert(flag.to_string(), None);
+                }
+            }
+        }
+
+        if let Some(allowed) = allowed_flags {
+            let allowed_set: HashSet<_> = allowed.iter().collect();
+            if let Some(unknown_flag) = flags.keys().find(|&key| !allowed_set.contains(key)) {
+                return Err(FlagParserError::UnkownFlag(unknown_flag.clone()));
+            }
+        }
+
+        Ok(Self { flags })
+    }
+
+    // Key is not present -> None
+    // Key is present but has no value -> Some(None)
+    // Key is present and has value -> Some(&Some(String))
+    pub fn get(&self, flag: &str) -> Option<&Option<String>> {
+        self.flags.get(flag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_help_flag() {
+        let parser =
+            FlagParser::new(vec!["my_program".to_string(), "--help".to_string()], None).unwrap();
+        assert!(parser.flags.contains_key("help"))
+    }
+
+    #[test]
+    fn test_config_flag() {
+        let parser = FlagParser::new(
+            vec![
+                "my_progam".to_string(),
+                "--config".to_string(),
+                "config.toml".to_string(),
+            ],
+            None,
+        )
+        .unwrap();
+        assert_eq!(parser.get("config"), Some(&Some("config.toml".to_string())));
+        assert_eq!(parser.get("non-existent-arg"), None);
+    }
+
+    #[test]
+    fn test_multiple_flags() {
+        let parser = FlagParser::new(
+            vec![
+                "my_progam".to_string(),
+                "--config".to_string(),
+                "config.toml".to_string(),
+                "--help".to_string(),
+                "--proxy-config".to_string(),
+                "another-config.toml".to_string(),
+                "--debug".to_string(),
+                "--verbose".to_string(),
+            ],
+            None,
+        )
+        .unwrap();
+        assert!(parser.flags.contains_key("help"));
+        assert!(parser.flags.contains_key("debug"));
+        assert!(parser.flags.contains_key("verbose"));
+        assert_eq!(parser.get("config"), Some(&Some("config.toml".to_string())));
+        assert_eq!(
+            parser.get("proxy-config"),
+            Some(&Some("another-config.toml".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_duplicate_args() {
+        let parser = FlagParser::new(
+            vec![
+                "my_progam".to_string(),
+                "--config".to_string(),
+                "config.toml".to_string(),
+                "--help".to_string(),
+                "--config".to_string(),
+                "another-config.toml".to_string(),
+            ],
+            None,
+        );
+        assert!(parser.is_err());
+    }
+
+    #[test]
+    fn test_allowed_flags() {
+        let parser = FlagParser::new(
+            vec![
+                "my_progam".to_string(),
+                "--config".to_string(),
+                "config.toml".to_string(),
+                "--help".to_string(),
+            ],
+            Some(vec!["config".to_string(), "help".to_string()]),
+        )
+        .unwrap();
+        assert!(parser.flags.contains_key("help"));
+        assert_eq!(parser.get("config"), Some(&Some("config.toml".to_string())));
+
+        let parser = FlagParser::new(
+            vec![
+                "my_progam".to_string(),
+                "--config".to_string(),
+                "config.toml".to_string(),
+                "--help".to_string(),
+            ],
+            Some(vec!["config".to_string()]),
+        );
+        assert!(parser.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 // and unsubscribe to a value
 
 pub mod errors;
+pub mod flag_parser;
 pub mod nkv;
 pub mod notifier;
 pub mod persist_value;

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -1,29 +1,56 @@
-use std::{env, fs};
+use std::{env, fs, path::PathBuf};
 use tempfile::TempDir;
 
+use nkv::flag_parser::FlagParser;
 use nkv::srv;
 
 const DEFAULT_URL: &str = "/tmp/nkv/nkv.sock";
 
+const HELP_MESSAGE: &str = "nkv-server [--dir path-to-store-data] [--sock path-to-socket] [--help]\
+    run notify key value server\
+    --dir - specify where to store files, if not specified it will create temprorary directory\
+    --sock - specify where to create UNIX socket to listen to connections to\
+    --help - display this message";
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
+    let allowed_flags = vec!["dir".to_string(), "help".to_string(), "sock".to_string()];
     let args: Vec<String> = env::args().collect();
-
-    let url = if args.len() > 1 {
-        &args[1]
-    } else {
-        DEFAULT_URL
+    let flags = match FlagParser::new(args, Some(allowed_flags)) {
+        Ok(res) => res,
+        Err(err) => {
+            println!("error: {}", err);
+            println!("{}", HELP_MESSAGE);
+            return;
+        }
     };
-    if fs::metadata(url).is_ok() {
-        fs::remove_file(url).expect("Failed to remove old socket");
+
+    if flags.get("help").is_some() {
+        println!("{}", HELP_MESSAGE);
+        return;
     }
 
-    let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+    let sock_path = match flags.get("sock") {
+        Some(&Some(ref val)) => val.clone(),
+        _ => DEFAULT_URL.to_string(),
+    };
+
+    if fs::metadata(&sock_path).is_ok() {
+        fs::remove_file(&sock_path).expect("Failed to remove old socket");
+    }
+
+    let dir = match flags.get("dir") {
+        Some(&Some(ref val)) => {
+            fs::create_dir_all(&val).expect(&format!("Failed to create directory {}", &val));
+            PathBuf::from(val)
+        }
+        _ => TempDir::new()
+            .expect("Failed to create temporary directory")
+            .into_path(),
+    };
 
     // creates a task where it waits to serve threads
-    let (mut srv, _cancel) = srv::Server::new(url.to_string(), temp_dir.path().to_path_buf())
-        .await
-        .unwrap();
+    let (mut srv, _cancel) = srv::Server::new(sock_path.to_string(), dir).await.unwrap();
 
     srv.serve().await;
 }


### PR DESCRIPTION
So that user can specify socket to connect to and
directory for nkv-server where it will store files. Instead of just specifying them in orderly manner I decided to use flags, because it is more straightforward approach and it is backward and forward-compatible friendly. In order to keep binary size as small as possible, instead of brining a ready library which would increase size for 30-50Kbytes, I wrote simple FlagParser, which does it's job and don't bring any 3rd party dependecies, apart from HashMap and HashSet from collections, which were already part of nkv.