### PR TITLE
Misc fixes to make nkv work under EVE 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "nkv"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nkv"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -16,7 +16,10 @@ OPTIONS:
       Supports UNIX socket paths.
 
   --help
-      Display this help message and exit.";
+      Display this help message and exit.
+
+  --version
+      Print nkv-client version and exit.";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
@@ -26,13 +29,20 @@ async fn main() {
         Ok(res) => res,
         Err(err) => {
             println!("error: {}", err);
+            println!("nkv-client, version: {}", env!("CARGO_PKG_VERSION"));
             println!("{}", HELP_MESSAGE);
             return;
         }
     };
 
     if flags.get("help").is_some() {
+        println!("nkv-client, version: {}", env!("CARGO_PKG_VERSION"));
         println!("{}", HELP_MESSAGE);
+        return;
+    }
+
+    if flags.get("version").is_some() {
+        println!(env!("CARGO_PKG_VERSION"));
         return;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,6 @@ impl NkvClient {
             .await
             .map_err(|_| tokio::io::Error::new(tokio::io::ErrorKind::Other, "read error"))?;
 
-        // println!("AAAMIGO {}", line);
         let response: ServerResponse = line.trim_end().parse().map_err(|_| {
             tokio::io::Error::new(
                 tokio::io::ErrorKind::Other,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ impl NkvClient {
         let response: ServerResponse = line.trim_end().parse().map_err(|_| {
             tokio::io::Error::new(
                 tokio::io::ErrorKind::Other,
-                "failed to parse message to UTF-8 String",
+                "failed to parse message to Server Response String",
             )
         })?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,7 @@ impl NkvClient {
             .await
             .map_err(|_| tokio::io::Error::new(tokio::io::ErrorKind::Other, "read error"))?;
 
+        // println!("AAAMIGO {}", line);
         let response: ServerResponse = line.trim_end().parse().map_err(|_| {
             tokio::io::Error::new(
                 tokio::io::ErrorKind::Other,

--- a/src/nkv.rs
+++ b/src/nkv.rs
@@ -183,7 +183,7 @@ impl<P: StorageEngine> NkvCore<P> {
         Ok(())
     }
 
-    pub fn get(&self, key: &str) -> Vec<Arc<[u8]>> {
+    pub fn get(&self, key: &str) -> HashMap<String, Arc<[u8]>> {
         self.storage.get(key)
     }
 
@@ -291,7 +291,9 @@ mod tests {
         nkv.put("key1", data.clone()).await?;
 
         let result = nkv.get("key1");
-        assert_eq!(result, vec!(Arc::from(data)));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("key1".to_string(), Arc::from(data));
+        assert_eq!(result, expected);
 
         Ok(())
     }
@@ -303,7 +305,7 @@ mod tests {
         let nkv = NkvCore::new(storage)?;
 
         let result = nkv.get("nonexistent_key");
-        assert_eq!(result, Vec::new());
+        assert_eq!(result, HashMap::new());
 
         Ok(())
     }
@@ -319,7 +321,7 @@ mod tests {
 
         nkv.delete("key1").await?;
         let result = nkv.get("key1");
-        assert_eq!(result, Vec::new());
+        assert_eq!(result, HashMap::new());
 
         Ok(())
     }
@@ -337,7 +339,9 @@ mod tests {
         nkv.put("key1", new_data.clone()).await?;
 
         let result = nkv.get("key1");
-        assert_eq!(result, vec!(Arc::from(new_data)));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("key1".to_string(), Arc::from(new_data));
+        assert_eq!(result, expected);
 
         Ok(())
     }
@@ -361,13 +365,19 @@ mod tests {
         let storage = FileStorage::new(path)?;
         let nkv = NkvCore::new(storage)?;
         let result = nkv.get("key1");
-        assert_eq!(result, vec!(Arc::from(data1)));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("key1".to_string(), Arc::from(data1));
+        assert_eq!(result, expected);
 
         let result = nkv.get("key2");
-        assert_eq!(result, vec!(Arc::from(data2)));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("key2".to_string(), Arc::from(data2));
+        assert_eq!(result, expected);
 
         let result = nkv.get("key3");
-        assert_eq!(result, vec!(Arc::from(data3)));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("key3".to_string(), Arc::from(data3));
+        assert_eq!(result, expected);
 
         Ok(())
     }
@@ -404,7 +414,9 @@ mod tests {
         }
 
         let result = nkv.get("key1");
-        assert_eq!(result, vec!(Arc::from(new_data)));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("key1".to_string(), Arc::from(new_data));
+        assert_eq!(result, expected);
 
         Ok(())
     }
@@ -441,7 +453,9 @@ mod tests {
         }
 
         let result = nkv.get("ks1.ks2.ks4");
-        assert_eq!(result, vec!(Arc::from(new_data)));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("ks1.ks2.ks4".to_string(), Arc::from(new_data));
+        assert_eq!(result, expected);
 
         Ok(())
     }
@@ -542,21 +556,26 @@ mod tests {
         nkv.put("ks1.ks2", data3.clone()).await?;
 
         let result = nkv.get("ks1.ks2.ks3.ks4.k");
-        assert_eq!(result, vec!(Arc::from(data1.clone())));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("ks1.ks2.ks3.ks4.k".to_string(), Arc::from(data1.clone()));
+        assert_eq!(result, expected);
+
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("ks1.ks2.ks3.ks4.k".to_string(), Arc::from(data1.clone()));
+        expected.insert("ks1".to_string(), Arc::from(data2.clone()));
+        expected.insert("ks1.ks2".to_string(), Arc::from(data3.clone()));
 
         let result = nkv.get("ks1.*");
-        assert!(result.iter().any(|x| &**x == data1.as_ref()));
-        assert!(result.iter().any(|x| &**x == data2.as_ref()));
-        assert!(result.iter().any(|x| &**x == data3.as_ref()));
+        assert_eq!(result, expected);
 
         let result = nkv.get("*");
-        assert!(result.iter().any(|x| &**x == data1.as_ref()));
-        assert!(result.iter().any(|x| &**x == data2.as_ref()));
-        assert!(result.iter().any(|x| &**x == data3.as_ref()));
+        assert_eq!(result, expected);
 
         let result = nkv.get("ks1.ks2.*");
-        assert!(result.iter().any(|x| &**x == data1.as_ref()));
-        assert!(result.iter().any(|x| &**x == data3.as_ref()));
+        let mut expected: HashMap<String, Arc<[u8]>> = HashMap::new();
+        expected.insert("ks1.ks2.ks3.ks4.k".to_string(), Arc::from(data1.clone()));
+        expected.insert("ks1.ks2".to_string(), Arc::from(data3.clone()));
+        assert_eq!(result, expected);
 
         Ok(())
     }

--- a/src/request_msg.rs
+++ b/src/request_msg.rs
@@ -214,7 +214,7 @@ impl fmt::Display for DataResp {
             // note: use same engine in decode as well
             let engine = base64::engine::general_purpose::STANDARD;
             let value = engine.encode(val);
-            write!(f, " {} {}", key, value)?
+            write!(f, " {} {}\n", key, value)?
         }
         Ok(())
     }

--- a/src/request_msg.rs
+++ b/src/request_msg.rs
@@ -326,11 +326,10 @@ impl FromStr for ServerResponse {
                 let base_resp: BaseResp = input_str.parse()?;
                 Ok(ServerResponse::Base(base_resp))
             }
-            3 => {
+            _ => {
                 let data_resp: DataResp = input_str.parse()?;
                 Ok(ServerResponse::Data(data_resp))
             }
-            _ => Err(SerializingError::UnknownCommand),
         }
     }
 }

--- a/src/request_msg.rs
+++ b/src/request_msg.rs
@@ -2,6 +2,13 @@
 
 // This file contains common messages which are
 // used between NkvClient and Server
+// Main design decision in client-server communication
+// is that we use UTF-8 valid strings, so that you can
+// open socket and write to server manually, no tools needed
+// With that using Rust Display traits to serialize and deserialize
+// ServerRequest and Response.
+// Debug formatting used to print the request in human-readable
+// format
 
 use base64::Engine;
 use std::collections::HashMap;
@@ -214,7 +221,7 @@ impl fmt::Display for DataResp {
             // note: use same engine in decode as well
             let engine = base64::engine::general_purpose::STANDARD;
             let value = engine.encode(val);
-            write!(f, " {} {}\n", key, value)?
+            write!(f, " {} {}", key, value)?
         }
         Ok(())
     }
@@ -226,8 +233,8 @@ impl fmt::Debug for DataResp {
 
         for (key, val) in self.data.iter() {
             match String::from_utf8(val.clone()) {
-                Ok(s) => write!(f, "{} {}", key, s)?,
-                Err(_) => write!(f, "{} {:?}", key, val)?,
+                Ok(s) => write!(f, " {} {}", key, s)?,
+                Err(_) => write!(f, " {} {:?}", key, val)?,
             }
         }
         Ok(())

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -36,7 +36,10 @@ OPTIONS:
         - `trace` : Maximum level of detailed logs.
 
   --help
-      Display this help message and exit.";
+      Display this help message and exit.
+
+  --version
+      Display nkv-server version and exit.";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
@@ -52,10 +55,16 @@ async fn main() {
         Ok(res) => res,
         Err(err) => {
             println!("error: {}", err);
+            println!("nkv-server, version: {}", env!("CARGO_PKG_VERSION"));
             println!("{}", HELP_MESSAGE);
             return;
         }
     };
+
+    if flags.get("version").is_some() {
+        println!(env!("CARGO_PKG_VERSION"));
+        return;
+    }
 
     // and_then flattens Option<&Option<String>> to Option<String>
     // we only care if this particular flag is specified with a value
@@ -67,6 +76,7 @@ async fn main() {
             Ok(l) => l,
             Err(err) => {
                 println!("error parsing log level: {}", err);
+                println!("nkv-server, version: {}", env!("CARGO_PKG_VERSION"));
                 println!("{}", HELP_MESSAGE);
                 return;
             }
@@ -76,6 +86,7 @@ async fn main() {
     let _guard = init_logging(level.clone(), flags.get("logs").and_then(|o| o.clone()));
 
     if flags.get("help").is_some() {
+        println!("nkv-server, version: {}", env!("CARGO_PKG_VERSION"));
         println!("{}", HELP_MESSAGE);
         return;
     }

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -323,7 +323,6 @@ impl Server {
             .into_iter()
             .map(|(k, v)| (k, v.as_ref().to_vec()))
             .collect();
-        println!("AMIGO {:?}", &data);
         let status = match nkv_resp.err {
             NotifyKeyValueError::NoError => true,
             _ => false,

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -323,6 +323,7 @@ impl Server {
             .into_iter()
             .map(|(k, v)| (k, v.as_ref().to_vec()))
             .collect();
+        println!("AMIGO {:?}", &data);
         let status = match nkv_resp.err {
             NotifyKeyValueError::NoError => true,
             _ => false,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 pub trait StorageEngine {
     fn put(&mut self, key: &str, data: Box<[u8]>) -> std::io::Result<()>;
-    fn get(&self, key: &str) -> Vec<Arc<[u8]>>;
+    fn get(&self, key: &str) -> HashMap<String, Arc<[u8]>>;
     fn delete(&self, key: &str) -> std::io::Result<()>;
 }


### PR DESCRIPTION
This PR overrules https://github.com/nkval/nkv/pull/46

It contains mixture of fixes introduced to nkv-client and server

- Fixes serialization/deseralization
- Introduces version to the package and the tool
- Introduces TREE command to nkv-client which shows you dependency of keys without printing the values for better visibility
- Major update for for getting * (all of the data) : now it's returned in map, instead of vector in key: value manner